### PR TITLE
Fixed typo in Arduino

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,7 +1,7 @@
 {
     "name": "ESP32-TWAI-CAN",
     "keywords": "can, twai, esp32, esp32-s3, esp32-s2, driver, arduino",
-    "description": "ESP32 driver for TWAI / CAN for Adruino using ESP-IDF drivers.",
+    "description": "ESP32 driver for TWAI / CAN for Arduino using ESP-IDF drivers.",
     "version": "1.0.2",
     "repository": {
         "type": "git",

--- a/library.properties
+++ b/library.properties
@@ -1,8 +1,8 @@
 name=ESP32-TWAI-CAN
-version=1.0.1
+version=1.0.2
 author=sorek.uk
 maintainer=sorek <contact@sorek.uk>
-sentence=ESP32 driver for TWAI / CAN for Adruino using ESP-IDF drivers.
+sentence=ESP32 driver for TWAI / CAN for Arduino using ESP-IDF drivers.
 paragraph=Supporting ESP32, ESP32-S2, ESP32-S3, ESP32-C3
 category=Communication
 url=https://github.com/handmade0octopus/ESP32-TWAI-CAN

--- a/src/ESP32-TWAI-CAN.hpp
+++ b/src/ESP32-TWAI-CAN.hpp
@@ -4,7 +4,7 @@
 /**
  * @file ESP32-TWAI-CAN.hpp
  * @author sorek (contact@sorek.uk)
- * @brief ESP32 driver for TWAI / CAN for Adruino using ESP-IDF drivers.
+ * @brief ESP32 driver for TWAI / CAN for Arduino using ESP-IDF drivers.
  * @version 1.0
  * @date 2023-12-15
  * 


### PR DESCRIPTION
Fixed typo in Arduino in 3 files; also updated the library version to 1.0.2 in `library.properties` as this was already seen in the `library.json` and I suspect this is preparing for a future release of the library.