### PR TITLE
Added and applied clang-format code style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,43 @@
+BasedOnStyle: Google
+Language: Cpp
+ColumnLimit: 120
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+SortIncludes: Never
+PPIndentWidth : 1
+IndentPPDirectives: AfterHash
+ReflowComments: true
+SpaceBeforeParens: Never
+SpacesBeforeTrailingComments: 1
+AlignTrailingComments: true
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros:
+  Enabled: true
+  AcrossEmptyLines: true
+  AcrossComments: true
+AlignConsecutiveAssignments:
+  Enabled: true
+  AcrossEmptyLines: false
+  AcrossComments: true
+  AlignCompound: true
+  PadOperators: true
+AlignConsecutiveDeclarations:
+  Enabled: true
+  AcrossEmptyLines: false
+  AcrossComments: true
+AlignEscapedNewlines: Left
+AccessModifierOffset: -2
+AlignArrayOfStructures: Right
+AlignOperands: Align
+AllowAllArgumentsOnNextLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortBlocksOnASingleLine: Empty
+BreakBeforeBinaryOperators: None
+BinPackArguments: false
+BinPackParameters: false
+DerivePointerAlignment: false
+PenaltyBreakAssignment: 4
+PenaltyExcessCharacter: 4
+PenaltyBreakBeforeFirstCallParameter: 1
+PointerAlignment: Left

--- a/examples/OBD2-querry/OBD2-querry.ino
+++ b/examples/OBD2-querry/OBD2-querry.ino
@@ -4,27 +4,26 @@
 // Showcasing simple use of ESP32-TWAI-CAN library driver.
 
 // Default for ESP32
-#define CAN_TX		5
-#define CAN_RX		4
-
+#define CAN_TX 5
+#define CAN_RX 4
 
 CanFrame rxFrame;
 
 void sendObdFrame(uint8_t obdId) {
-	CanFrame obdFrame = { 0 };
-	obdFrame.identifier = 0x7DF; // Default OBD2 address;
-	obdFrame.extd = 0;
-	obdFrame.data_length_code = 8;
-	obdFrame.data[0] = 2;
-	obdFrame.data[1] = 1;
-	obdFrame.data[2] = obdId;
-	obdFrame.data[3] = 0xAA;    // Best to use 0xAA (0b10101010) instead of 0
-	obdFrame.data[4] = 0xAA;    // CAN works better this way as it needs
-	obdFrame.data[5] = 0xAA;    // to avoid bit-stuffing
-	obdFrame.data[6] = 0xAA;
-	obdFrame.data[7] = 0xAA;
-    // Accepts both pointers and references 
-    ESP32Can.writeFrame(obdFrame);  // timeout defaults to 1 ms
+    CanFrame obdFrame         = {0};
+    obdFrame.identifier       = 0x7DF; // Default OBD2 address;
+    obdFrame.extd             = 0;
+    obdFrame.data_length_code = 8;
+    obdFrame.data[0]          = 2;
+    obdFrame.data[1]          = 1;
+    obdFrame.data[2]          = obdId;
+    obdFrame.data[3]          = 0xAA; // Best to use 0xAA (0b10101010) instead of 0
+    obdFrame.data[4]          = 0xAA; // CAN works better this way as it needs
+    obdFrame.data[5]          = 0xAA; // to avoid bit-stuffing
+    obdFrame.data[6]          = 0xAA;
+    obdFrame.data[7]          = 0xAA;
+    // Accepts both pointers and references
+    ESP32Can.writeFrame(obdFrame); // timeout defaults to 1 ms
 }
 
 void setup() {
@@ -32,18 +31,18 @@ void setup() {
     Serial.begin(115200);
 
     // Set pins
-	ESP32Can.setPins(CAN_TX, CAN_RX);
-	
+    ESP32Can.setPins(CAN_TX, CAN_RX);
+
     // You can set custom size for the queues - those are default
     ESP32Can.setRxQueueSize(5);
-	ESP32Can.setTxQueueSize(5);
+    ESP32Can.setTxQueueSize(5);
 
     // .setSpeed() and .begin() functions require to use TwaiSpeed enum,
     // but you can easily convert it from numerical value using .convertSpeed()
     ESP32Can.setSpeed(ESP32Can.convertSpeed(500));
 
     // You can also just use .begin()..
-    if(ESP32Can.begin()) {
+    if (ESP32Can.begin()) {
         Serial.println("CAN bus started!");
     } else {
         Serial.println("CAN bus failed!");
@@ -51,7 +50,7 @@ void setup() {
 
     // or override everything in one command;
     // It is also safe to use .begin() without .end() as it calls it internally
-    if(ESP32Can.begin(ESP32Can.convertSpeed(500), CAN_TX, CAN_RX, 10, 10)) {
+    if (ESP32Can.begin(ESP32Can.convertSpeed(500), CAN_TX, CAN_RX, 10, 10)) {
         Serial.println("CAN bus started!");
     } else {
         Serial.println("CAN bus failed!");
@@ -59,19 +58,19 @@ void setup() {
 }
 
 void loop() {
-    static uint32_t lastStamp = 0;
-    uint32_t currentStamp = millis();
-    
-    if(currentStamp - lastStamp > 1000) {   // sends OBD2 request every second
+    static uint32_t lastStamp    = 0;
+    uint32_t        currentStamp = millis();
+
+    if (currentStamp - lastStamp > 1000) { // sends OBD2 request every second
         lastStamp = currentStamp;
         sendObdFrame(5); // For coolant temperature
     }
 
     // You can set custom timeout, default is 1000
-    if(ESP32Can.readFrame(rxFrame, 1000)) {
+    if (ESP32Can.readFrame(rxFrame, 1000)) {
         // Comment out if too many frames
         Serial.printf("Received frame: %03X  \r\n", rxFrame.identifier);
-        if(rxFrame.identifier == 0x7E8) {   // Standard OBD2 frame responce ID
+        if (rxFrame.identifier == 0x7E8) {                                   // Standard OBD2 frame responce ID
             Serial.printf("Collant temp: %3d°C \r\n", rxFrame.data[3] - 40); // Convert to °C
         }
     }

--- a/library.json
+++ b/library.json
@@ -14,13 +14,12 @@
             "+<ESP32-TWAI-CAN.cpp>"
         ]
     },
-    "authors":
-    [
-      {
-         "name": "sorek",
-         "email": "contact@sorek.uk",
-         "url": "http://sorek.uk",
-         "maintainer": true
-      }
+    "authors": [
+        {
+            "name": "sorek",
+            "email": "contact@sorek.uk",
+            "url": "http://sorek.uk",
+            "maintainer": true
+        }
     ]
 }

--- a/src/ESP32-TWAI-CAN.cpp
+++ b/src/ESP32-TWAI-CAN.cpp
@@ -1,13 +1,13 @@
 #include "ESP32-TWAI-CAN.hpp"
 
-
 void TwaiCAN::setSpeed(TwaiSpeed twaiSpeed) {
     if(twaiSpeed < TWAI_SPEED_SIZE) speed = twaiSpeed;
 }
 
+// clang-format off
 uint32_t TwaiCAN::getSpeedNumeric() { 
     uint32_t actualSpeed = 500;
-	switch(getSpeed()) {
+    switch(getSpeed()) {
         default: break;
         #if (SOC_TWAI_BRP_MAX > 256)
         case TWAI_SPEED_1KBPS   :   actualSpeed = 1   ; break;
@@ -19,20 +19,22 @@ uint32_t TwaiCAN::getSpeedNumeric() {
         case TWAI_SPEED_16KBPS  :   actualSpeed = 16  ; break;
         case TWAI_SPEED_20KBPS  :   actualSpeed = 20  ; break;
         #endif
-		case TWAI_SPEED_50KBPS  :   actualSpeed = 50  ; break;
-		case TWAI_SPEED_100KBPS :   actualSpeed = 100 ; break;
-		case TWAI_SPEED_125KBPS :   actualSpeed = 125 ; break;
-		case TWAI_SPEED_250KBPS :   actualSpeed = 250 ; break;
-		case TWAI_SPEED_500KBPS :   actualSpeed = 500 ; break;
-		case TWAI_SPEED_800KBPS :   actualSpeed = 800 ; break;
-		case TWAI_SPEED_1000KBPS:   actualSpeed = 1000; break;
-	}
+        case TWAI_SPEED_50KBPS  :   actualSpeed = 50  ; break;
+        case TWAI_SPEED_100KBPS :   actualSpeed = 100 ; break;
+        case TWAI_SPEED_125KBPS :   actualSpeed = 125 ; break;
+        case TWAI_SPEED_250KBPS :   actualSpeed = 250 ; break;
+        case TWAI_SPEED_500KBPS :   actualSpeed = 500 ; break;
+        case TWAI_SPEED_800KBPS :   actualSpeed = 800 ; break;
+        case TWAI_SPEED_1000KBPS:   actualSpeed = 1000; break;
+    }
     return actualSpeed;
 }
+// clang-format on
 
+// clang-format off
 TwaiSpeed TwaiCAN::convertSpeed(uint16_t canSpeed) { 
     TwaiSpeed actualSpeed = getSpeed();
-	switch(canSpeed) {
+    switch(canSpeed) {
         default: break;
         #if (SOC_TWAI_BRP_MAX > 256)
         case 1:     actualSpeed = TWAI_SPEED_1KBPS;     break;
@@ -45,19 +47,25 @@ TwaiSpeed TwaiCAN::convertSpeed(uint16_t canSpeed) {
         case 16:    actualSpeed = TWAI_SPEED_16KBPS;    break;
         case 20:    actualSpeed = TWAI_SPEED_20KBPS;    break;
         #endif
-		case 50:    actualSpeed = TWAI_SPEED_50KBPS;   break;
-		case 100:   actualSpeed = TWAI_SPEED_100KBPS;   break;
-		case 125:   actualSpeed = TWAI_SPEED_125KBPS;   break;
-		case 250:   actualSpeed = TWAI_SPEED_250KBPS;   break;
-		case 500:   actualSpeed = TWAI_SPEED_500KBPS;   break;
-		case 800:   actualSpeed = TWAI_SPEED_800KBPS;   break;
-		case 1000:  actualSpeed = TWAI_SPEED_1000KBPS;  break;
-	}
+        case 50:    actualSpeed = TWAI_SPEED_50KBPS;    break;
+        case 100:   actualSpeed = TWAI_SPEED_100KBPS;   break;
+        case 125:   actualSpeed = TWAI_SPEED_125KBPS;   break;
+        case 250:   actualSpeed = TWAI_SPEED_250KBPS;   break;
+        case 500:   actualSpeed = TWAI_SPEED_500KBPS;   break;
+        case 800:   actualSpeed = TWAI_SPEED_800KBPS;   break;
+        case 1000:  actualSpeed = TWAI_SPEED_1000KBPS;  break;
+    }
     return actualSpeed;
 }
+// clang-format on
 
-void TwaiCAN::setTxQueueSize(uint16_t txQueue) { if(txQueue != 0xFFFF) txQueueSize = txQueue; }
-void TwaiCAN::setRxQueueSize(uint16_t rxQueue) { if(rxQueue != 0xFFFF) rxQueueSize = rxQueue; }
+void TwaiCAN::setTxQueueSize(uint16_t txQueue) {
+    if(txQueue != 0xFFFF) txQueueSize = txQueue;
+}
+
+void TwaiCAN::setRxQueueSize(uint16_t rxQueue) {
+    if(rxQueue != 0xFFFF) rxQueueSize = rxQueue;
+}
 
 bool TwaiCAN::getStatusInfo() {
     return ESP_OK == twai_get_status_info(&status);
@@ -79,8 +87,7 @@ uint32_t TwaiCAN::inRxQueue() {
     return ret;
 };
 
-uint32_t TwaiCAN::rxErrorCounter()
-{
+uint32_t TwaiCAN::rxErrorCounter() {
     uint32_t ret = 0;
     if(getStatusInfo()) {
         ret = status.rx_error_counter;
@@ -88,8 +95,7 @@ uint32_t TwaiCAN::rxErrorCounter()
     return ret;
 };
 
-uint32_t TwaiCAN::txErrorCounter()
-{
+uint32_t TwaiCAN::txErrorCounter() {
     uint32_t ret = 0;
     if(getStatusInfo()) {
         ret = status.tx_error_counter;
@@ -97,8 +103,7 @@ uint32_t TwaiCAN::txErrorCounter()
     return ret;
 };
 
-uint32_t TwaiCAN::rxMissedCounter()
-{
+uint32_t TwaiCAN::rxMissedCounter() {
     uint32_t ret = 0;
     if(getStatusInfo()) {
         ret = status.rx_missed_count;
@@ -106,8 +111,7 @@ uint32_t TwaiCAN::rxMissedCounter()
     return ret;
 };
 
-uint32_t TwaiCAN::txFailedCounter()
-{
+uint32_t TwaiCAN::txFailedCounter() {
     uint32_t ret = 0;
     if(getStatusInfo()) {
         ret = status.tx_failed_count;
@@ -115,8 +119,7 @@ uint32_t TwaiCAN::txFailedCounter()
     return ret;
 };
 
-uint32_t TwaiCAN::busErrCounter()
-{
+uint32_t TwaiCAN::busErrCounter() {
     uint32_t ret = 0;
     if(getStatusInfo()) {
         ret = status.bus_error_count;
@@ -124,8 +127,7 @@ uint32_t TwaiCAN::busErrCounter()
     return ret;
 };
 
-uint32_t TwaiCAN::canState()
-{
+uint32_t TwaiCAN::canState() {
     uint32_t ret = 0;
     if(getStatusInfo()) {
         ret = (uint32_t)status.state;
@@ -133,14 +135,17 @@ uint32_t TwaiCAN::canState()
     return ret;
 };
 
-
 bool TwaiCAN::setPins(int8_t txPin, int8_t rxPin) {
     bool ret = !init;
 
-    if(txPin >= 0) tx = txPin;
-    else ret = false;
-    if(rxPin >= 0) rx = rxPin;
-    else ret = false;
+    if(txPin >= 0)
+        tx = txPin;
+    else
+        ret = false;
+    if(rxPin >= 0)
+        rx = rxPin;
+    else
+        ret = false;
 
     LOG_TWAI("Wrong pins or CAN bus running already!");
     return ret;
@@ -152,27 +157,22 @@ bool TwaiCAN::recover(void) {
         LOG_TWAI("CAN bus status read failed!");
         return false;
     }
-    switch(status.state)
-    {
-      case TWAI_STATE_BUS_OFF:
-      {
-        LOG_TWAI("Bus was off, starting recovery");
-        return twai_initiate_recovery();
-      }
-      case TWAI_STATE_RECOVERING:
-      {
-        // Already recovering, nothing to do
-        return true;
-      }
-      case TWAI_STATE_STOPPED:
-      {
-        // Stopped, nothing to do
-        return true;
-      }
-      default:
-      {
-        LOG_TWAI("Wrong state for recovery!");
-      }
+    switch(status.state) {
+        case TWAI_STATE_BUS_OFF: {
+            LOG_TWAI("Bus was off, starting recovery");
+            return twai_initiate_recovery();
+        }
+        case TWAI_STATE_RECOVERING: {
+            // Already recovering, nothing to do
+            return true;
+        }
+        case TWAI_STATE_STOPPED: {
+            // Stopped, nothing to do
+            return true;
+        }
+        default: {
+            LOG_TWAI("Wrong state for recovery!");
+        }
     }
 
     return false;
@@ -184,48 +184,51 @@ bool TwaiCAN::restart(void) {
         LOG_TWAI("CAN bus status read failed!");
         return false;
     }
-    switch(status.state)
-    {
-      case TWAI_STATE_STOPPED:
-      {
-        // Stopped, restart
-        return twai_start();
-      }
-      default:
-      {
-        LOG_TWAI("Wrong state for restart!");
-      }
+    switch(status.state) {
+        case TWAI_STATE_STOPPED: {
+            // Stopped, restart
+            return twai_start();
+        }
+        default: {
+            LOG_TWAI("Wrong state for restart!");
+        }
     }
 
     return false;
 }
 
-bool TwaiCAN::begin(TwaiSpeed twaiSpeed, 
-                    int8_t txPin, int8_t rxPin,
-                    uint16_t txQueue, uint16_t rxQueue,
+bool TwaiCAN::begin(TwaiSpeed              twaiSpeed,
+                    int8_t                 txPin,
+                    int8_t                 rxPin,
+                    uint16_t               txQueue,
+                    uint16_t               rxQueue,
                     twai_filter_config_t*  fConfig,
                     twai_general_config_t* gConfig,
-                    twai_timing_config_t*  tConfig)
-                    {
-
+                    twai_timing_config_t*  tConfig) {
     bool ret = false;
     if(end()) {
         init = true;
         setSpeed(twaiSpeed);
         setPins(txPin, rxPin);
-        
+
         gpio_reset_pin((gpio_num_t)rx);
         gpio_reset_pin((gpio_num_t)tx);
 
         setTxQueueSize(txQueue);
         setRxQueueSize(rxQueue);
 
-        twai_general_config_t g_config = {.mode = TWAI_MODE_NORMAL, .tx_io = (gpio_num_t) tx, .rx_io = (gpio_num_t) rx, \
-                                                .clkout_io = TWAI_IO_UNUSED, .bus_off_io = TWAI_IO_UNUSED,      \
-                                                .tx_queue_len = txQueueSize, .rx_queue_len = rxQueueSize,       \
-                                                .alerts_enabled = TWAI_ALERT_NONE,  .clkout_divider = 0,        \
-                                                .intr_flags = ESP_INTR_FLAG_LEVEL1};
+        twai_general_config_t g_config = {.mode           = TWAI_MODE_NORMAL,
+                                          .tx_io          = (gpio_num_t)tx,
+                                          .rx_io          = (gpio_num_t)rx,
+                                          .clkout_io      = TWAI_IO_UNUSED,
+                                          .bus_off_io     = TWAI_IO_UNUSED,
+                                          .tx_queue_len   = txQueueSize,
+                                          .rx_queue_len   = rxQueueSize,
+                                          .alerts_enabled = TWAI_ALERT_NONE,
+                                          .clkout_divider = 0,
+                                          .intr_flags     = ESP_INTR_FLAG_LEVEL1};
 
+        // clang-format off
         twai_timing_config_t t_config[TWAI_SPEED_SIZE] = {
             #if (SOC_TWAI_BRP_MAX > 256)
             TWAI_TIMING_CONFIG_1KBITS(),
@@ -245,6 +248,7 @@ bool TwaiCAN::begin(TwaiSpeed twaiSpeed,
             TWAI_TIMING_CONFIG_800KBITS(),
             TWAI_TIMING_CONFIG_1MBITS()
         };
+        // clang-format on
 
         twai_filter_config_t f_config = TWAI_FILTER_CONFIG_ACCEPT_ALL();
 
@@ -252,15 +256,15 @@ bool TwaiCAN::begin(TwaiSpeed twaiSpeed,
         if(!tConfig) tConfig = &t_config[speed];
         if(!fConfig) fConfig = &f_config;
 
-            //Install TWAI driver
-        if (twai_driver_install(gConfig, tConfig, fConfig) == ESP_OK) {
+        // Install TWAI driver
+        if(twai_driver_install(gConfig, tConfig, fConfig) == ESP_OK) {
             LOG_TWAI("Driver installed");
         } else {
             LOG_TWAI("Failed to install driver");
         }
 
-        //Start TWAI driver
-        if (twai_start() == ESP_OK) {
+        // Start TWAI driver
+        if(twai_start() == ESP_OK) {
             LOG_TWAI("Driver started");
             ret = true;
         } else {
@@ -271,20 +275,19 @@ bool TwaiCAN::begin(TwaiSpeed twaiSpeed,
     return ret;
 }
 
-
 bool TwaiCAN::end() {
     bool ret = false;
     if(init) {
-        //Stop the TWAI driver
-        if (twai_stop() == ESP_OK) {
+        // Stop the TWAI driver
+        if(twai_stop() == ESP_OK) {
             LOG_TWAI("Driver stopped\n");
             ret = true;
         } else {
             LOG_TWAI("Failed to stop driver\n");
         }
 
-        //Uninstall the TWAI driver
-        if (twai_driver_uninstall() == ESP_OK) {
+        // Uninstall the TWAI driver
+        if(twai_driver_uninstall() == ESP_OK) {
             LOG_TWAI("Driver uninstalled\n");
             ret &= true;
         } else {
@@ -292,7 +295,8 @@ bool TwaiCAN::end() {
             ret &= false;
         }
         init = !ret;
-    } else ret = true;
+    } else
+        ret = true;
     return ret;
 }
 

--- a/src/ESP32-TWAI-CAN.hpp
+++ b/src/ESP32-TWAI-CAN.hpp
@@ -7,42 +7,44 @@
  * @brief ESP32 driver for TWAI / CAN for Adruino using ESP-IDF drivers.
  * @version 1.0
  * @date 2023-12-15
- * 
+ *
  * @copyright Copyright (c) 2023
- * 
+ *
  * I tried to create as simple and as lightweight Arduino ESP32 TWAI / CAN library
  * as possible. Currently testing it has very small footprint both on ESP32 and ESP32-S3.
- * 
+ *
  * Simply declare your rx and tx frames using 'CanFrame' structures and you are good to go!
- * 
+ *
  */
+
 #ifdef ARDUINO
-#include <Arduino.h>
+# include <Arduino.h>
 #else
-#include "inttypes.h"
+# include "inttypes.h"
 #endif
+
 #include "driver/twai.h"
 
-
 // Uncomment or declare before importing header
-//#define LOG_TWAI log_e
-//#define LOG_TWAI_TX log_e
-//#define LOG_TWAI_RX log_e
+// #define LOG_TWAI log_e
+// #define LOG_TWAI_TX log_e
+// #define LOG_TWAI_RX log_e
 
 #ifndef LOG_TWAI
-#define LOG_TWAI
+# define LOG_TWAI
 #endif
 
 #ifndef LOG_TWAI_TX
-#define LOG_TWAI_TX
+# define LOG_TWAI_TX
 #endif
 
 #ifndef LOG_TWAI_RX
-#define LOG_TWAI_RX
+# define LOG_TWAI_RX
 #endif
 
 typedef twai_message_t CanFrame;
 
+// clang-format off
 enum TwaiSpeed : uint8_t {
     #if (SOC_TWAI_BRP_MAX > 256)
     TWAI_SPEED_1KBPS,
@@ -63,19 +65,20 @@ enum TwaiSpeed : uint8_t {
     TWAI_SPEED_1000KBPS,
     TWAI_SPEED_SIZE
 };
+// clang-format on
 
 class TwaiCAN {
- public:
+  public:
     TwaiCAN() {}
 
     // Call before begin!
-    void setSpeed(TwaiSpeed);
-    TwaiSpeed getSpeed()        { return speed; };
+    void      setSpeed(TwaiSpeed);
+    TwaiSpeed getSpeed() { return speed; };
     uint32_t  getSpeedNumeric();
 
     // Converts from numeric CAN speed to enum values: setSpeed(convertSpeed(500));
     TwaiSpeed convertSpeed(uint16_t canSpeed = 0);
-    
+
     // Size of queues for TWAI-CAN driver - remember about memory constrains!
     void setTxQueueSize(uint16_t);
     void setRxQueueSize(uint16_t);
@@ -90,23 +93,24 @@ class TwaiCAN {
     uint32_t txFailedCounter();
     uint32_t busErrCounter();
     uint32_t canState();
-    
-    
+
     bool setPins(int8_t txPin, int8_t rxPin);
 
     // Everything is defaulted so you can just call .begin() or .begin(TwaiSpeed)
     // Calling begin() to change speed works, it will disable current driver first
-    bool begin(TwaiSpeed twaiSpeed = TWAI_SPEED_SIZE, 
-                    int8_t txPin = -1, int8_t rxPin = -1,
-                    uint16_t txQueue = 0xFFFF, uint16_t rxQueue = 0xFFFF,
-                    twai_filter_config_t*  fConfig = nullptr,
-                    twai_general_config_t* gConfig = nullptr,
-                    twai_timing_config_t*  tConfig = nullptr);
+    bool begin(TwaiSpeed              twaiSpeed = TWAI_SPEED_SIZE,
+               int8_t                 txPin     = -1,
+               int8_t                 rxPin     = -1,
+               uint16_t               txQueue   = 0xFFFF,
+               uint16_t               rxQueue   = 0xFFFF,
+               twai_filter_config_t*  fConfig   = nullptr,
+               twai_general_config_t* gConfig   = nullptr,
+               twai_timing_config_t*  tConfig   = nullptr);
 
     bool recover(void);
 
     bool restart(void);
-    
+
     // Pass frame either by reference or pointer; timeout in ms, you can pass 0 for non blocking
     inline bool IRAM_ATTR readFrame(CanFrame& frame, uint32_t timeout = 1000) { return readFrame(&frame, timeout); }
     inline bool IRAM_ATTR readFrame(CanFrame* frame, uint32_t timeout = 1000) {
@@ -131,19 +135,19 @@ class TwaiCAN {
 
     bool end();
 
- protected:
+  protected:
     twai_status_info_t status;
-    bool getStatusInfo();
+    bool               getStatusInfo();
 
- private:
-    bool init = false;
-    int8_t tx = 5;
-    int8_t rx = 4;
-    uint16_t txQueueSize = 5;
-    uint16_t rxQueueSize = 5;
-    TwaiSpeed speed = TWAI_SPEED_500KBPS;
+  private:
+    bool      init        = false;
+    int8_t    tx          = 5;
+    int8_t    rx          = 4;
+    uint16_t  txQueueSize = 5;
+    uint16_t  rxQueueSize = 5;
+    TwaiSpeed speed       = TWAI_SPEED_500KBPS;
 };
 
 extern TwaiCAN ESP32Can;
 
-#endif//ESP32_TWAI_CAN_HPP
+#endif // ESP32_TWAI_CAN_HPP


### PR DESCRIPTION
Added a `.clang-format` proposal that seems consistent with the main code style of the library and applied it to all source code (including the `.ino` example) to show what the impact would be.

Not a problem if this PR isn't accepted, as it is your project and I'm happy with the results the driver/library provides in my testing the TWAI / CAN with some M5Stack ESP32 devices; regardless of the code style/formatting. If the PR is appreciated/accepted, I would see it as a way to pay back for the help this library has provided already.