### PR TITLE
Fixed example typo (in name/path), description, and code layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,27 +14,26 @@ Here is simple example how to query and receive OBD2 PID frames:
 #include <ESP32-TWAI-CAN.hpp>
 
 // Default for ESP32
-#define CAN_TX		5
-#define CAN_RX		4
-
+#define CAN_TX 5
+#define CAN_RX 4
 
 CanFrame rxFrame;
 
 void sendObdFrame(uint8_t obdId) {
-	CanFrame obdFrame = { 0 };
-	obdFrame.identifier = 0x7DF; // Default OBD2 address;
-	obdFrame.extd = 0;
-	obdFrame.data_length_code = 8;
-	obdFrame.data[0] = 2;
-	obdFrame.data[1] = 1;
-	obdFrame.data[2] = obdId;
-	obdFrame.data[3] = 0xAA;    // Best to use 0xAA (0b10101010) instead of 0
-	obdFrame.data[4] = 0xAA;    // CAN works better this way as it needs
-	obdFrame.data[5] = 0xAA;    // to avoid bit-stuffing
-	obdFrame.data[6] = 0xAA;
-	obdFrame.data[7] = 0xAA;
-    // Accepts both pointers and references 
-    ESP32Can.writeFrame(obdFrame);  // timeout defaults to 1 ms
+    CanFrame obdFrame         = {0};
+    obdFrame.identifier       = 0x7DF; // Default OBD2 address;
+    obdFrame.extd             = 0;
+    obdFrame.data_length_code = 8;
+    obdFrame.data[0]          = 2;
+    obdFrame.data[1]          = 1;
+    obdFrame.data[2]          = obdId;
+    obdFrame.data[3]          = 0xAA; // Best use 0xAA (0b10101010) instead of 0
+    obdFrame.data[4]          = 0xAA; // TWAI / CAN works better this way, as it
+    obdFrame.data[5]          = 0xAA; // needs to avoid bit-stuffing
+    obdFrame.data[6]          = 0xAA;
+    obdFrame.data[7]          = 0xAA;
+    // Accepts both pointers and references
+    ESP32Can.writeFrame(obdFrame); // timeout defaults to 1 ms
 }
 
 void setup() {
@@ -42,11 +41,11 @@ void setup() {
     Serial.begin(115200);
 
     // Set pins
-	ESP32Can.setPins(CAN_TX, CAN_RX);
-	
+    ESP32Can.setPins(CAN_TX, CAN_RX);
+
     // You can set custom size for the queues - those are default
     ESP32Can.setRxQueueSize(5);
-	ESP32Can.setTxQueueSize(5);
+    ESP32Can.setTxQueueSize(5);
 
     // .setSpeed() and .begin() functions require to use TwaiSpeed enum,
     // but you can easily convert it from numerical value using .convertSpeed()
@@ -69,19 +68,19 @@ void setup() {
 }
 
 void loop() {
-    static uint32_t lastStamp = 0;
-    uint32_t currentStamp = millis();
-    
-    if(currentStamp - lastStamp > 1000) {   // sends OBD2 request every second
+    static uint32_t lastStamp    = 0;
+    uint32_t        currentStamp = millis();
+
+    if(currentStamp - lastStamp > 1000) { // sends OBD2 request every second
         lastStamp = currentStamp;
         sendObdFrame(5); // For coolant temperature
     }
 
     // You can set custom timeout, default is 1000
     if(ESP32Can.readFrame(rxFrame, 1000)) {
-        // Comment out if too many requests 
-        Serial.printf("Received frame: %03X \r\n", rxFrame.identifier);
-        if(rxFrame.identifier == 0x7E8) {   // Standard OBD2 frame responce ID
+        // Comment out if too many frames
+        Serial.printf("Received frame: %03X  \r\n", rxFrame.identifier);
+        if(rxFrame.identifier == 0x7E8) {                                    // Standard OBD2 frame responce ID
             Serial.printf("Collant temp: %3d°C \r\n", rxFrame.data[3] - 40); // Convert to °C
         }
     }
@@ -95,11 +94,11 @@ You can also setup your own masks and configurations:
 // Everything is defaulted so you can just call .begin() or .begin(TwaiSpeed)
 // Calling begin() to change speed works, it will disable current driver first
 bool begin(TwaiSpeed twaiSpeed = TWAI_SPEED_500KBPS, 
-                int8_t txPin = -1, int8_t rxPin = -1,
-                uint16_t txQueue = 0xFFFF, uint16_t rxQueue = 0xFFFF,
-                twai_filter_config_t*  fConfig = nullptr,
-                twai_general_config_t* gConfig = nullptr,
-                twai_timing_config_t*  tConfig = nullptr);
+           int8_t txPin = -1, int8_t rxPin = -1,
+           uint16_t txQueue = 0xFFFF, uint16_t rxQueue = 0xFFFF,
+           twai_filter_config_t*  fConfig = nullptr,
+           twai_general_config_t* gConfig = nullptr,
+           twai_timing_config_t*  tConfig = nullptr);
 ```
 
 Follow `soc/twai_types.h` for more info:

--- a/examples/OBD2-query/OBD2-query.ino
+++ b/examples/OBD2-query/OBD2-query.ino
@@ -1,7 +1,7 @@
-#include <ESP32-TWAI-CAN.hpp>
+// Example sketch for the ESP32-TWAI-CAN library driver,
+// showing how to query OBD2 over TWAI / CAN for coolant temperature.
 
-// Simple sketch that querries OBD2 over CAN for coolant temperature
-// Showcasing simple use of ESP32-TWAI-CAN library driver.
+#include <ESP32-TWAI-CAN.hpp>
 
 // Default for ESP32
 #define CAN_TX 5
@@ -17,9 +17,9 @@ void sendObdFrame(uint8_t obdId) {
     obdFrame.data[0]          = 2;
     obdFrame.data[1]          = 1;
     obdFrame.data[2]          = obdId;
-    obdFrame.data[3]          = 0xAA; // Best to use 0xAA (0b10101010) instead of 0
-    obdFrame.data[4]          = 0xAA; // CAN works better this way as it needs
-    obdFrame.data[5]          = 0xAA; // to avoid bit-stuffing
+    obdFrame.data[3]          = 0xAA; // Best use 0xAA (0b10101010) instead of 0
+    obdFrame.data[4]          = 0xAA; // TWAI / CAN works better this way, as it
+    obdFrame.data[5]          = 0xAA; // needs to avoid bit-stuffing
     obdFrame.data[6]          = 0xAA;
     obdFrame.data[7]          = 0xAA;
     // Accepts both pointers and references
@@ -42,7 +42,7 @@ void setup() {
     ESP32Can.setSpeed(ESP32Can.convertSpeed(500));
 
     // You can also just use .begin()..
-    if (ESP32Can.begin()) {
+    if(ESP32Can.begin()) {
         Serial.println("CAN bus started!");
     } else {
         Serial.println("CAN bus failed!");
@@ -50,7 +50,7 @@ void setup() {
 
     // or override everything in one command;
     // It is also safe to use .begin() without .end() as it calls it internally
-    if (ESP32Can.begin(ESP32Can.convertSpeed(500), CAN_TX, CAN_RX, 10, 10)) {
+    if(ESP32Can.begin(ESP32Can.convertSpeed(500), CAN_TX, CAN_RX, 10, 10)) {
         Serial.println("CAN bus started!");
     } else {
         Serial.println("CAN bus failed!");
@@ -61,16 +61,16 @@ void loop() {
     static uint32_t lastStamp    = 0;
     uint32_t        currentStamp = millis();
 
-    if (currentStamp - lastStamp > 1000) { // sends OBD2 request every second
+    if(currentStamp - lastStamp > 1000) { // sends OBD2 request every second
         lastStamp = currentStamp;
         sendObdFrame(5); // For coolant temperature
     }
 
     // You can set custom timeout, default is 1000
-    if (ESP32Can.readFrame(rxFrame, 1000)) {
+    if(ESP32Can.readFrame(rxFrame, 1000)) {
         // Comment out if too many frames
         Serial.printf("Received frame: %03X  \r\n", rxFrame.identifier);
-        if (rxFrame.identifier == 0x7E8) {                                   // Standard OBD2 frame responce ID
+        if(rxFrame.identifier == 0x7E8) {                                    // Standard OBD2 frame responce ID
             Serial.printf("Collant temp: %3d°C \r\n", rxFrame.data[3] - 40); // Convert to °C
         }
     }


### PR DESCRIPTION
The example filename and path contained a typo `querry` (instead of `query`), which is fixed in this PR. Also reworded the example sketch description for readability and applied the `.clang-format` code layout.

These changes are also reflected in the example (partially) copied into the README file.